### PR TITLE
change api level to 27 for UI test

### DIFF
--- a/.github/workflows/build_pull_request.yaml
+++ b/.github/workflows/build_pull_request.yaml
@@ -41,6 +41,31 @@ jobs:
         with:
           name: test-reports
           path: '**/build/reports/tests/'
+          
+  run_android_tests:
+    name: Android UI Test
+    runs-on: macos-latest # more reliable for ui tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # make gradlew executable
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Run Android UI Tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 27
+          script: ./gradlew connectedDebugAndroidTest
+
+      - name: Upload Android Test Reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: android-test-reports
+          path: '**/build/reports/androidTests/'
+
 
   assemble_debug_apk:
     name: Assemble debug APK


### PR DESCRIPTION
api 29 is currently timeout and makes test run for indefinite amount of time. More information can be found [here](https://github.com/ReactiveCircus/android-emulator-runner/issues/168#issuecomment-881279868)