### PR TITLE
Bugfix: launching account fragment caused AuthToken to be deleted by RoomDB

### DIFF
--- a/app/src/main/java/com/codingwithmitch/openapi/di/account/AccountModule.kt
+++ b/app/src/main/java/com/codingwithmitch/openapi/di/account/AccountModule.kt
@@ -6,6 +6,7 @@ import com.codingwithmitch.openapi.business.interactors.account.GetAccountFromCa
 import com.codingwithmitch.openapi.business.interactors.account.UpdateAccount
 import com.codingwithmitch.openapi.business.interactors.account.UpdatePassword
 import com.codingwithmitch.openapi.business.datasource.cache.account.AccountDao
+import com.codingwithmitch.openapi.business.datasource.cache.auth.AuthTokenDao
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -20,9 +21,10 @@ object AccountModule {
     @Provides
     fun provideGetAccount(
         service: OpenApiMainService,
-        cache: AccountDao,
+        accountCache: AccountDao,
+        tokenCache: AuthTokenDao,
     ): GetAccount{
-        return GetAccount(service, cache)
+        return GetAccount(service, accountCache, tokenCache)
     }
 
     @Singleton


### PR DESCRIPTION
The way to reproduce the bug:
- login into your account and remain on 'Home' fragment
- open 'Database Inspector', open 'auth_token' and  turn on 'Live updates'
- Navigate to 'Account' fragment

_Bug: The token gets deleted_. This causes user to be asked for login when closing the app, simply because of visiting the 'Account' fragment.

Test environment: AVD, x86, Android 11, Android Studio 4.2.2.